### PR TITLE
SDCISA-19522 make enums publicly accessible by using extracted schema

### DIFF
--- a/apikana-parent/pom.xml
+++ b/apikana-parent/pom.xml
@@ -20,7 +20,7 @@
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-maven-plugin</artifactId>
                 <configuration>
-                    <sourceDirectory>${basedir}/target/node/dist/model/json-schema-v4-full</sourceDirectory>
+                    <sourceDirectory>${basedir}/target/node/dist/model/json-schema-v4</sourceDirectory>
                     <includeJsr303Annotations>true</includeJsr303Annotations>
                     <useJakartaValidation>true</useJakartaValidation>
                     <useJodaDates>true</useJodaDates>


### PR DESCRIPTION
Using the `json-schema-v4-full` may increase performance, but will make enums only accessible via parent class. So now we are still using v4 spec, but the extracted json schema output.